### PR TITLE
Fix: Write all bytes of UTF-8 String

### DIFF
--- a/KeypadMapper3/keypadMapper3/src/main/java/de/enaikoon/android/keypadmapper3/writers/OsmWriter.java
+++ b/KeypadMapper3/keypadMapper3/src/main/java/de/enaikoon/android/keypadmapper3/writers/OsmWriter.java
@@ -3,13 +3,14 @@ package de.enaikoon.android.keypadmapper3.writers;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.io.UnsupportedEncodingException;
 import java.util.Calendar;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import android.util.Log;
-import hu.meskobalazs.android.keypadmapper.KeypadMapperApplication;
 import de.enaikoon.android.keypadmapper3.settings.KeypadMapperSettings;
+import hu.meskobalazs.android.keypadmapper.KeypadMapperApplication;
 import de.enaikoon.android.keypadmapper3.utils.ByteSearch;
 
 public class OsmWriter {
@@ -84,7 +85,7 @@ public class OsmWriter {
             byte [] buffer = new byte[ bufferSize ];
             
             osmFile = new RandomAccessFile(settings.getLastOsmFile(), "rw");
-            if (osmFile.length() < (OSM_HEADER.getBytes().length + OSM_FOOTER.getBytes().length)) {
+            if (osmFile.length() < (OSM_HEADER.getBytes("UTF-8").length + OSM_FOOTER.getBytes("UTF-8").length)) {
                 Log.e("KeypadMapper", "Cannot undo - no nodes");
                 return;
             }
@@ -154,10 +155,10 @@ public class OsmWriter {
             writeString(OSM_HEADER);
         } else {
             osmFile = new RandomAccessFile(settings.getLastOsmFile(), "rw");
-            Log.d("KeypadMapper", "header + footer len: " + (OSM_HEADER.getBytes().length + OSM_FOOTER.getBytes().length) + " osm len:" + osmFile.length());
+            Log.d("KeypadMapper", "header + footer len: " + (OSM_HEADER.getBytes("UTF-8").length + OSM_FOOTER.getBytes("UTF-8").length) + " osm len:" + osmFile.length());
             if (osmFile.length() > 0) {
-                if (osmFile.length() >= (OSM_HEADER.getBytes().length + OSM_FOOTER.getBytes().length)) {
-                    osmFile.seek(osmFile.length() - OSM_FOOTER.getBytes().length);
+                if (osmFile.length() >= (OSM_HEADER.getBytes("UTF-8").length + OSM_FOOTER.getBytes("UTF-8").length)) {
+                    osmFile.seek(osmFile.length() - OSM_FOOTER.getBytes("UTF-8").length);
                 } else {
                     osmFile.seek(osmFile.length());
                 }
@@ -167,6 +168,10 @@ public class OsmWriter {
     }
     
     public static int getEmptyFileSize() {
-        return OSM_HEADER.getBytes().length + OSM_FOOTER.getBytes().length;
+        try {
+            return OSM_HEADER.getBytes("UTF-8").length + OSM_FOOTER.getBytes("UTF-8").length;
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/KeypadMapper3/keypadMapper3/src/main/java/de/enaikoon/android/keypadmapper3/writers/OsmWriter.java
+++ b/KeypadMapper3/keypadMapper3/src/main/java/de/enaikoon/android/keypadmapper3/writers/OsmWriter.java
@@ -49,13 +49,13 @@ public class OsmWriter {
      */
     public void addNode(double lat, double lon, Map<String, String> tags) throws IOException {
         int nodeId = -KeypadMapperApplication.getInstance().getMapper().getHouseNumberCount();
-        
-        osmFile.writeBytes("\t<node id=\"" + nodeId + "\" visible=\"true\" lat=\"" + lat
+
+        writeString("\t<node id=\"" + nodeId + "\" visible=\"true\" lat=\"" + lat
                 + "\" lon=\"" + lon + "\">\n");
         for (Entry<String, String> entry : tags.entrySet()) {
             if (entry.getValue() != null && entry.getValue().length() != 0
                     && !entry.getValue().equalsIgnoreCase("null")) {
-                osmFile.writeBytes("\t\t<tag k=\"" + entry.getKey() + "\" v=\"" + entry.getValue()
+                writeString("\t\t<tag k=\"" + entry.getKey() + "\" v=\"" + entry.getValue()
                         + "\"/>\n");
             }
         }
@@ -63,8 +63,12 @@ public class OsmWriter {
 
     }
 
+    private void writeString(String str) throws IOException {
+        osmFile.write(str.getBytes("UTF-8"));
+    }
+
     public void close() throws IOException {
-        osmFile.writeBytes(OSM_FOOTER);
+        writeString(OSM_FOOTER);
         osmFile.close();
     }
 
@@ -147,7 +151,7 @@ public class OsmWriter {
             settings.setLastOsmFile(newFile);
             osmFile = new RandomAccessFile(newFile, "rw");
             
-            osmFile.writeBytes(OSM_HEADER);
+            writeString(OSM_HEADER);
         } else {
             osmFile = new RandomAccessFile(settings.getLastOsmFile(), "rw");
             Log.d("KeypadMapper", "header + footer len: " + (OSM_HEADER.getBytes().length + OSM_FOOTER.getBytes().length) + " osm len:" + osmFile.length());


### PR DESCRIPTION
According to JavaDoc `RandomAccessFile.writeBytes()` writes each character in the string by discarding its high eight bits. This is ok for latin charactes, but it corruptes non-latin charactes. For example: russian charactes.

That's why I used `RandomAccessFile.write()` and `String.getBytes("UTF-8"))` to write all bytes of charactes

This PR fixes these issues:
https://github.com/msemm/Keypad-Mapper-3/issues/1
https://github.com/msemm/Keypad-Mapper-3/issues/4